### PR TITLE
Allow to specify refresh speed of the live preview

### DIFF
--- a/www/live.php
+++ b/www/live.php
@@ -12,6 +12,27 @@
   <link rel="stylesheet" href="js-css/pikrellcam.css" />
   <script src="js-css/pikrellcam.js"></script>
   <script src="js-css/expandable-panels.js"></script>
+  
+  <script type="text/javascript">
+   var mjpeg;
+   var url = window.location.search;
+   var refreshtime = url.substring(url.lastIndexOf("=")+1);
+   if (refreshtime == "") { refreshtime = 150; }
+
+	function mjpeg_read()
+        {
+        setTimeout("mjpeg.src = 'mjpeg_read.php?time=' + new Date().getTime();", refreshtime);
+        }
+
+	function mjpeg_start()
+        {
+        mjpeg = document.getElementById("mjpeg_image");
+        mjpeg.onload = mjpeg_read;
+        mjpeg.onerror = mjpeg_read;
+        mjpeg_read();
+        }
+  </script>
+  
   <link rel="stylesheet" href="js-css/expandable-panels.css" />
   <style>
 	*{margin:0;padding:0;}


### PR DESCRIPTION
This pull request allow end-user to specify refresh rate of the live.php window
for example
https://xxxxxx/live.php?refresh=1500
in nothing is specified we keep the default value of 150 ms