### PR TITLE
Enable streaming video; remove double -r 6

### DIFF
--- a/scripts-dist/_timelapse-convert
+++ b/scripts-dist/_timelapse-convert
@@ -50,7 +50,7 @@ echo "tl_inform_convert start $SERIES" > $COMMAND_FIFO
 cd $MEDIA_DIR/timelapse
 nice -2 avconv -r 6 -i $FILENAME_FORMAT \
 		-b:v 6M -maxrate 6M -minrate 1M -bufsize 4M \
-		-r 6 -vcodec libx264 -crf 20 -g 4 \
+		-vcodec libx264 -crf 20 -g 4 -movflags faststart \
 		$SERIES.mp4
 
 mv $SERIES.mp4 $VIDEOFILE_MP4


### PR DESCRIPTION
The created mp4 files are not streaming video files but "standard" mp4 files with the metadata (moov atom) at the end.
To make it possible to simply stream them, add the "-movflags faststart" option to the avconv/ffmpeg command. This will add a second pass, but minimal as it is only a metadata copy (copies entire file), but no encoding.
Also remove the double "-r 6"