### PR TITLE
Replace deprecated use of `create_function`

### DIFF
--- a/www/media-archive.php
+++ b/www/media-archive.php
@@ -177,8 +177,8 @@ function media_array_create()
 	else
 		$media_array = media_dir_array_create($media_dir);
 
-	usort($media_array, create_function('$a, $b',
-				'return strcmp($a["mtime"], $b["mtime"]);'));
+	usort($media_array, function($a, $b) { return strcmp($a["mtime"], $b["mtime"]); });
+	
 	krsort($media_array);
 	$media_array = array_values($media_array);
 	$media_array_size = count($media_array);


### PR DESCRIPTION
As reported by @Egregius in #41 create_function is deprecated since PHP 7.2. This PR replaces it with an anonymous function, which are supported since PHP 5.3, so should still be backwards compatible with older Raspberry Pis running Jessie.