### PR TITLE
Python 3 compatibility in example scripts

### DIFF
--- a/scripts-dist/ds18b20.py
+++ b/scripts-dist/ds18b20.py
@@ -4,16 +4,16 @@ import sys
 output = "terminal"
 
 if len (sys.argv) < 2 :
-	print "Usage: " + sys.argv[0] + " [C|F] {fifo}"
-	print "    C or F must be given"
-	print "    If \"fifo\" arg is present, write to PiKrellCam FIFO"
+	print("Usage: " + sys.argv[0] + " [C|F] {fifo}")
+	print("    C or F must be given")
+	print("    If \"fifo\" arg is present, write to PiKrellCam FIFO")
 	sys.exit(1)
 
 mode = sys.argv[1]
 if (mode != "F") and (mode != "C"):
-	print "Usage: " + sys.argv[0] + " [C|F] {fifo}"
-	print "    C or F must be given"
-	print "    If \"fifo\" arg is present, write to PiKrellCam FIFO"
+	print("Usage: " + sys.argv[0] + " [C|F] {fifo}")
+	print("    C or F must be given")
+	print("    If \"fifo\" arg is present, write to PiKrellCam FIFO")
 	sys.exit(1)
 
 if len (sys.argv) == 3 :
@@ -30,9 +30,8 @@ def read_temp(device):
 	global mode
 	for count in range(0, 3):
 		path = "/sys/bus/w1/devices/" + device.rstrip() + "/w1_slave"
-		file = open(path)
-		lines = file.read()
-		file.close()
+		with open(path) as file:
+			lines = file.read()
 
 		line1 = lines.split("\n")[0]
 		line2 = lines.split("\n")[1]
@@ -69,6 +68,6 @@ try:
 		fifo.write("annotate_string append ds18b20 " + out_string + "\n")
 		fifo.close()
 	else:
-		print out_string
+		print(out_string)
 except:
-	print "no devices"
+	print("no devices")

--- a/scripts-dist/example-motion-detects-fifo
+++ b/scripts-dist/example-motion-detects-fifo
@@ -18,11 +18,17 @@
 import os
 import sys
 import signal
-import fcntl
-import atexit
 import select
-import StringIO
 import time
+
+try:
+	from StringIO import StringIO
+except ImportError:
+	# Python 3
+	from io import StringIO as _StringIO
+	def StringIO(initial_value=b''):
+		"""Take bytes as input but return a unicode IO object"""
+		return _StringIO(initial_value.decode())
 
 
 # Turn on pikrellcam motion detects writing to the motion_detects_FIFO
@@ -34,7 +40,7 @@ os.system('echo "motion_detects_fifo_enable on" > /home/pi/pikrellcam/www/FIFO')
 # read from the motion_detects_FIFO and exit.
 #
 def signal_handler(signum, frame):
-    print '  Turning off motion_detects_fifo_enable'
+	print('  Turning off motion_detects_fifo_enable')
 	os.system('echo "motion_detects_fifo_enable off" > /home/pi/pikrellcam/www/FIFO')
 	sys.exit(0)
 
@@ -62,39 +68,38 @@ while True:
 	#   region vectors.  If you care only about overall frame motion, look
 	#   for 'f' frame vectors.
 	#
-	lines = StringIO.StringIO(data)
+	lines = StringIO(data)
 	for line in lines.readlines():
 		line = line.strip('\n')
-		print "FIFO read: " + line
+		print("FIFO read: " + line)
 
 		# If some program sends a "motion_detects_fifo_enable off" to the
 		# command FIFO, an <off> tag will be written to the motion_detects_FIFO.
 		#
 		if (line.find('<off>') == 0):
-			print "    detected motion_detects_fifo_enable off - exiting."
+			print("    detected motion_detects_fifo_enable off - exiting.")
 			sys.exit(1)
 		elif (line.find('<motion') == 0):
 			state = 'motion'
 			# <motion t >  where t is system time with .1 second precision
 			m, t, b = line.split()
-			print "    motion detected - system time " + t + " => " + time.asctime( time.localtime( int(float(t)) ) )
+			print("    motion detected - system time " + t + " => " + time.asctime( time.localtime( int(float(t)) ) ))
 		elif (line.find('</motion>') == 0):
-			print ""
+			print("")
 			state = 'wait'
 		elif (state == 'motion'):
 			if (line[0] == "f"):
 				r, x, y, dx, dy, mag, count = line.split()
-				print "    motion vector - frame:" + " mag=" + mag + " count=" + count
+				print("    motion vector - frame:" + " mag=" + mag + " count=" + count)
 			elif (line[0].isdigit()):
 				r, x, y, dx, dy, mag, count = line.split()
-				print "    motion vector - region " + line[0] + ": mag=" + mag + " count=" + count
+				print("    motion vector - region " + line[0] + ": mag=" + mag + " count=" + count)
 			elif (line[0] == "b"):
 				b, count = line.split()
-				print "    burst detect - count=" + count
+				print("    burst detect - count=" + count)
 			elif (line[0] == "e"):
 				e, code = line.split()
-				print "    external trigger - code: " + code
+				print("    external trigger - code: " + code)
 			elif (line[0] == "a"):
 				a, level = line.split()
-				print "    audio trigger - level=" + level
-
+				print("    audio trigger - level=" + level)

--- a/scripts-dist/example-motion-events
+++ b/scripts-dist/example-motion-events
@@ -13,7 +13,6 @@
 # is run from a terminal.
 
 import sys
-import socket
 import time
 
 filename = '/run/pikrellcam/motion-events'
@@ -23,7 +22,7 @@ state = 'wait'
 event = 1
 
 # sys.argv[1] is the $e value: motion, external or audio
-print "on_motion_begin triggered by: " + sys.argv[1]
+print("on_motion_begin triggered by: " + sys.argv[1])
 
 while 1:
 	where = file.tell()
@@ -34,7 +33,7 @@ while 1:
 		continue
 	line = line.strip('\n')
 	if (line.find('<motion') == 0):
-		print "  motion event number: " + str(event)
+		print("  motion event number: " + str(event))
 		event = event + 1
 		state = 'motion'
 	elif (line.find('</motion>') == 0):
@@ -43,13 +42,13 @@ while 1:
 		sys.exit(1)
 	elif (state == 'motion'):
 		if (line[0].isdigit()):
-			print "    motion direction - region: " + line[0]
+			print("    motion direction - region: " + line[0])
 		elif (line[0] == "b"):
 			b, count = line.split() 
-			print "    burst detect - count: " + count
+			print("    burst detect - count: " + count)
 		elif (line[0] == "e"):
 			e, code = line.split() 
-			print "    external trigger - code: " + code
+			print("    external trigger - code: " + code)
 		elif (line[0] == "a"):
 			a, level = line.split() 
-			print "    audio trigger - level: " + level
+			print("    audio trigger - level: " + level)

--- a/scripts-dist/example-motion-send-alarm1
+++ b/scripts-dist/example-motion-send-alarm1
@@ -14,7 +14,6 @@
 # With this script only one alarm is sent per motion detect video.
 # See example-motion-send-alarm2 for a different approach.
 
-import sys
 import socket
 import time
 
@@ -40,6 +39,6 @@ send_socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
 msg_id = 1
 for x in range(0, repeat):
     msg = "%s:%d %s message alarm" % (from_host, msg_id, to_hosts)
-#    print msg
-    send_socket.sendto(msg, (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
+#    print(msg)
+    send_socket.sendto(msg.encode(), (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
     time.sleep(delay)

--- a/scripts-dist/example-motion-send-alarm2
+++ b/scripts-dist/example-motion-send-alarm2
@@ -38,7 +38,7 @@ import time
 #   It should be greater than the holdoff in pkc-alarm.
 #
 to_hosts = "gkrellm4,rpi0,rpi1"
-motion_region = 3
+motion_region = '3'
 magnitude_limit = 12
 count_limit = 20
 holdoff = 6
@@ -75,7 +75,7 @@ while 1:
 		file.seek(where)
 		continue
 	line = line.strip('\n')
-#	print '==>' + line
+#	print('==>' + line)
 	if (line.find('<motion') == 0):
 		state = 'motion'
 	elif (line.find('</motion>') == 0):
@@ -83,16 +83,16 @@ while 1:
 	elif (line.find('<end>') == 0):
 		sys.exit(1)
 	elif (state == 'motion'):
-		if (line.startswith(str(motion_region))):
-#			print line
+		if (line.startswith(motion_region)):
+#			print(line)
 			tnow = time.time()
 			if (tnow >= tsent + holdoff):
 				r, x, y, dx, dy, mag, count = line.split()
 				if (int(mag) >= magnitude_limit and int(count) >= count_limit):
 					for x in range(0, repeat):
 						msg = "%s:%d %s message alarm" % (from_host, msg_id, to_hosts)
-#						 print msg
-						send_socket.sendto(msg, (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
+#						 print(msg)
+						send_socket.sendto(msg.encode(), (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
 						time.sleep(delay)
 					tsent = tnow
 					msg_id = msg_id + 1

--- a/scripts-dist/pkc-alarm
+++ b/scripts-dist/pkc-alarm
@@ -62,9 +62,9 @@ def host_match(from_host, to_hosts):
 
 
 while True:
-	line = sock.recv(256)
+	line = sock.recv(256).decode()
 	tnow = time.time()
-#	print line
+#	print(line)
 
 	from_host, to_hosts, msg_type, msg_body = line.split(' ', 3)
 	if (msg_type != 'message' or msg_body != 'alarm'):
@@ -84,7 +84,7 @@ while True:
 		continue
 
 	if (id != idprev or tnow - tplay >= holdoff):
-		print audio_command
+		print(audio_command)
 		os.system(audio_command)
 		tplay = tnow
 

--- a/scripts-dist/pkc-motion
+++ b/scripts-dist/pkc-motion
@@ -27,11 +27,11 @@ repeat = 4
 delay = .05
 
 def usage():
-	print "usage: pkc-motion {host|host-list|all} <on|off>"
-	print "    Multicast a motion_enable command to PiKrellCams on a LAN."
-	print "    If host, host-list or all is not specified, all is assumed."
-	print "    host-list is a comma separated list of hosts."
-	print "    on or off must be given."
+	print("usage: pkc-motion {host|host-list|all} <on|off>")
+	print("    Multicast a motion_enable command to PiKrellCams on a LAN.")
+	print("    If host, host-list or all is not specified, all is assumed.")
+	print("    host-list is a comma separated list of hosts.")
+	print("    on or off must be given.")
 	sys.exit()
 
 argc = len(sys.argv)
@@ -48,14 +48,14 @@ if onoff == "on":
 elif onoff == "off":
 	msg_id = 2
 else:
-	print 'Bad arg: ' + onoff
+	print('Bad arg: ' + onoff)
 	usage()
 
 hostname = socket.gethostname()
 
 for x in range(1, repeat + 1):
 	msg = "%s:%d %s command @motion_enable %s" % (hostname, msg_id, hosts, onoff)
-#	print msg
-	send_socket.sendto(msg, (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
+#	print(msg)
+	send_socket.sendto(msg.encode(), (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
 	time.sleep(delay)
 

--- a/scripts-dist/pkc-reboot
+++ b/scripts-dist/pkc-reboot
@@ -32,10 +32,10 @@ repeat = 4
 delay = .05
 
 def usage():
-	print "usage: pkc-reboot <host|host-list|all>"
-	print "Multicast a reboot command to PiKrellCams on a LAN."
-	print "    host, host-list or all must be given."
-	print "    host-list is a comma separated list of hosts."
+	print("usage: pkc-reboot <host|host-list|all>")
+	print("Multicast a reboot command to PiKrellCams on a LAN.")
+	print("    host, host-list or all must be given.")
+	print("    host-list is a comma separated list of hosts.")
 	sys.exit()
 
 argc = len(sys.argv)
@@ -44,7 +44,7 @@ if argc == 1:
 elif argc == 2:
 	hosts = sys.argv[1]
 else:
-	print 'Bad number of args'
+	print('Bad number of args')
 	usage()
 
 hostname = socket.gethostname()
@@ -52,8 +52,8 @@ hostname = socket.gethostname()
 msg_id = 1
 for x in range(0, repeat):
 	msg = "%s:%d %s command @reboot" % (hostname, msg_id, hosts)
-#	print msg
-	send_socket.sendto(msg, (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
+#	print(msg)
+	send_socket.sendto(msg.encode(), (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
 	time.sleep(delay)
 
 
@@ -64,6 +64,6 @@ time.sleep(1)
 msg_id = 2
 for x in range(0, repeat):
 	msg = "%s:%d %s command @reboot" % (hostname, msg_id, hosts)
-#	print msg
-	send_socket.sendto(msg, (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
+#	print(msg)
+	send_socket.sendto(msg.encode(), (PKC_MULTICAST_GROUP, PKC_MULTICAST_PORT))
 	time.sleep(delay)

--- a/scripts-dist/pkc-recv
+++ b/scripts-dist/pkc-recv
@@ -17,4 +17,4 @@ mreq = struct.pack("4sl", socket.inet_aton(PKC_MULTICAST_GROUP_IP), socket.INADD
 sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
 
 while True:
-	print sock.recv(1024)
+	print(sock.recv(1024).decode())


### PR DESCRIPTION
Python 2 will be retired in [less than 5 months](https://pythonclock.org/), and Python 3 is apparently the default in [Buster](https://wiki.debian.org/Python#Supported_Python_Versions).

I'm also working on packaging this for Arch (where Python 3 has been the default for nearly a decade), and this would be one less thing that I'd need to patch.

Note that I haven't tested these yet because I'm not currently using them, and I'm working on some other things, but these were all the incompatibilities I noticed from reading the code, and as far as I know everything should still work with Python 2.

P.S. I'd like to speak to you about some things regarding the Arch packaging, is there a good way for me to contact you? Feel free to email me at the address in my profile if that's your preferred method and you'd rather not share your address here.